### PR TITLE
Updated to support elixir 1.7+ and get resolve some warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ GenServer API. There are 2 additional callbacks `connect/2` and `disconnect/2`:
 There is an example of a simple TCP connection process in
 `examples/tcp_connection/`.
 
+Only Elixir 1.7+ is supported.
 
 ## License
 

--- a/lib/connection.ex
+++ b/lib/connection.ex
@@ -426,9 +426,9 @@ defmodule Connection do
       :exit, reason ->
         init_stop(starter, name, reason)
       :error, reason ->
-        init_stop(starter, name, {reason, System.stacktrace()})
+        init_stop(starter, name, {reason, __STACKTRACE__})
       :throw, value ->
-        reason = {{:nocatch, value}, System.stacktrace()}
+        reason = {{:nocatch, value}, __STACKTRACE__}
         init_stop(starter, name, reason)
     else
       {:ok, mod_state} ->
@@ -488,7 +488,7 @@ defmodule Connection do
       apply(mod, :handle_call, [request, from, mod_state])
     catch
       :throw, value ->
-        :erlang.raise(:error, {:nocatch, value}, System.stacktrace())
+        :erlang.raise(:error, {:nocatch, value}, __STACKTRACE__)
     else
       {:noreply, mod_state} = noreply ->
         put_elem(noreply, 1, %{s | mod_state: mod_state})
@@ -537,7 +537,7 @@ defmodule Connection do
       apply(mod, :code_change, [old_vsn, mod_state, extra])
     catch
       :throw, value ->
-        exit({{:nocatch, value}, System.stacktrace()})
+        exit({{:nocatch, value}, __STACKTRACE__})
     else
       {:ok, mod_state} ->
         {:ok, %{s | mod_state: mod_state}}
@@ -578,7 +578,7 @@ defmodule Connection do
       apply(mod, :terminate, [stop, mod_state])
     catch
       :throw, value ->
-        :erlang.raise(:error, {:nocatch, value}, System.stacktrace())
+        :erlang.raise(:error, {:nocatch, value}, __STACKTRACE__)
     else
       _ when stop in [:normal, :shutdown] ->
         :ok
@@ -622,13 +622,13 @@ defmodule Connection do
       apply(mod, :connect, [info, mod_state])
     catch
       :exit, reason ->
-        report_reason = {:EXIT, {reason, System.stacktrace()}}
+        report_reason = {:EXIT, {reason, __STACKTRACE__}}
         enter_terminate(mod, mod_state, name, reason, report_reason)
       :error, reason ->
-        reason = {reason, System.stacktrace()}
+        reason = {reason, __STACKTRACE__}
         enter_terminate(mod, mod_state, name, reason, {:EXIT, reason})
       :throw, value ->
-        reason = {{:nocatch, value}, System.stacktrace()}
+        reason = {{:nocatch, value}, __STACKTRACE__}
         enter_terminate(mod, mod_state, name, reason, {:EXIT, reason})
     else
       {:ok, mod_state} ->
@@ -654,13 +654,13 @@ defmodule Connection do
       apply(mod, :terminate, [reason, mod_state])
     catch
       :exit, reason ->
-        report_reason = {:EXIT, {reason, System.stacktrace()}}
+        report_reason = {:EXIT, {reason, __STACKTRACE__}}
         enter_stop(mod, mod_state, name, reason, report_reason)
       :error, reason ->
-        reason = {reason, System.stacktrace()}
+        reason = {reason, __STACKTRACE__}
         enter_stop(mod, mod_state, name, reason, {:EXIT, reason})
       :throw, value ->
-        reason = {{:nocatch, value}, System.stacktrace()}
+        reason = {{:nocatch, value}, __STACKTRACE__}
         enter_stop(mod, mod_state, name, reason, {:EXIT, reason})
     else
       _ ->
@@ -741,7 +741,7 @@ defmodule Connection do
       apply(mod, :connect, [info, mod_state])
     catch
       class, reason ->
-        stack = System.stacktrace()
+        stack = __STACKTRACE__
         callback_stop(class, reason, stack, %{s | mod_state: mod_state})
     else
       {:ok, mod_state} ->
@@ -767,7 +767,7 @@ defmodule Connection do
       apply(mod, :disconnect, [info, mod_state])
     catch
       class, reason ->
-        stack = System.stacktrace()
+        stack = __STACKTRACE__
         callback_stop(class, reason, stack, %{s | mod_state: mod_state})
     else
       {:connect, info, mod_state} ->
@@ -810,7 +810,7 @@ defmodule Connection do
       apply(mod, fun, [msg, mod_state])
     catch
       :throw, value ->
-        :erlang.raise(:error, {:nocatch, value}, System.stacktrace())
+        :erlang.raise(:error, {:nocatch, value}, __STACKTRACE__)
     else
       {:noreply, mod_state} = noreply ->
         put_elem(noreply, 1, %{s | mod_state: mod_state})

--- a/mix.exs
+++ b/mix.exs
@@ -4,29 +4,37 @@ defmodule Connection.Mixfile do
   @version "1.0.4"
 
   def project do
-    [app: :connection,
-     version: @version,
-     elixir: "~> 1.2",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     description: description(),
-     package: package(),
-     docs: docs(),
-     deps: deps()]
+    [
+      app: :connection,
+      version: @version,
+      elixir: "~> 1.7",
+      build_embedded: Mix.env == :prod,
+      start_permanent: Mix.env == :prod,
+      description: description(),
+      package: package(),
+      docs: docs(),
+      deps: deps()
+    ]
   end
 
   def application do
-    [applications: []]
+    [
+      applications: []
+    ]
   end
 
   defp deps() do
-    [{:ex_doc, "~> 0.13", only: :dev}]
+    [
+      {:ex_doc, "~> 0.22", only: :dev}
+    ]
   end
 
   defp docs do
-    [source_url: "https://github.com/fishcakez/connection",
-     source_ref: "v#{@version}",
-     main: Connection]
+    [
+      source_url: "https://github.com/fishcakez/connection",
+      source_ref: "v#{@version}",
+      main: Connection
+    ]
   end
 
   defp description do
@@ -36,7 +44,9 @@ defmodule Connection.Mixfile do
   end
 
   defp package do
-    %{licenses: ["Apache 2.0"],
-      links: %{"Github" => "https://github.com/fishcakez/connection"}}
+    %{
+      licenses: ["Apache 2.0"],
+      links: %{"Github" => "https://github.com/fishcakez/connection"}
+    }
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,8 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{
+  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], [], "hexpm", "db7b13d74a9edc54d3681762154d164d4a661cd27673cca80760344449877664"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.10", "6603d7a603b9c18d3d20db69921527f82ef09990885ed7525003c7fe7dc86c56", [:mix], [], "hexpm", "8e2d5370b732385db2c9b22215c3f59c84ac7dda7ed7e544d7c459496ae519c0"},
+  "ex_doc": {:hex, :ex_doc, "0.22.5", "d2312c99f52cb1f98371e28f68259b4e0cee13d0122baedaf74a8e44e299a35b", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "d6ac685fd0b226805db96f7fbb384cbf8e01903ddb902ff66c9b189104705cae"},
+  "makeup": {:hex, :makeup, "1.0.3", "e339e2f766d12e7260e6672dd4047405963c5ec99661abdc432e6ec67d29ef95", [:mix], [{:nimble_parsec, "~> 0.5", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "2e9b4996d11832947731f7608fed7ad2f9443011b3b479ae288011265cdd3dad"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.1", "4f0e96847c63c17841d42c08107405a005a2680eb9c7ccadfd757bd31dabccfb", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "f2438b1a80eaec9ede832b5c41cd4f373b38fd7aa33e3b22d9db79e640cbde11"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.6.0", "32111b3bf39137144abd7ba1cce0914533b2d16ef35e8abc5ec8be6122944263", [:mix], [], "hexpm", "27eac315a94909d4dc68bc07a4a83e06c8379237c5ea528a9acff4ca1c873c52"},
+}


### PR DESCRIPTION
## Summary

Bumped `ex_doc` to `~> 0.22`
Bumped Elixir requirement to `1.7`
Replaced `System.stacktrace/0` with `__STACKTRACE__` (hence the elixir bump)

Also tweaked the mixfile to match with current standard

## Related

Closes #12