### PR TITLE
Unlock CI by updating to latest Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: test
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.7.4
-              otp: 19.3.6.13
+              elixir: 1.7
+              otp: 19
           - pair:
-              elixir: main
+              elixir: 1.13
               otp: 24
             lint: lint
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
   push:
     branches:
-      - master
+    - master
+  schedule:
+    - cron: "0 0 1 */1 *"
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Elixir ${{matrix.pair.elixir}} / OTP ${{matrix.pair.otp}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
       MIX_ENV: test
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
               elixir: 1.7.4
               otp: 19.3.6.13
           - pair:
-              elixir: 1.11.3
-              otp: 23.2.5
+              elixir: main
+              otp: 24
             lint: lint
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.7
-              otp: 19
+              elixir: 1.7.4
+              otp: 19.3.6.13
           - pair:
-              elixir: 1.13
-              otp: 24
+              elixir: 1.13.3
+              otp: 24.2.2
             lint: lint
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,7 @@ on:
   pull_request:
   push:
     branches:
-    - master
-  schedule:
-    - cron: "0 0 1 */1 *"
+      - master
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: Elixir ${{matrix.pair.elixir}} / OTP ${{matrix.pair.otp}}
     runs-on: ubuntu-latest
     env:
       MIX_ENV: test


### PR DESCRIPTION
Hi! Ubuntu 16.04 virtual environments are [no longer available](https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/) on GitHub Actions. This PR changes jobs to run on latest Ubuntu (so this situation won't happen again).

I have also changed matrix to run on the latest Elixir/OTP set and added a schedule to run tests monthly. I think this may be helpful to preemptively avoid future breakages. Let me know if you want having this change; I can drop these commits 😄 