### PR TITLE
Update ci runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.10.4
-              otp: 21.3.8.24
+              elixir: 1.7.4
+              otp: 20.3
           - pair:
               elixir: 1.13.4
               otp: 24.3.4.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Elixir ${{matrix.pair.elixir}} / OTP ${{matrix.pair.otp}}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       MIX_ENV: test
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
               otp: 24.3.4.2
             lint: lint
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: erlef/setup-elixir@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.7.4
-              otp: 19.3.6.13
+              elixir: 1.10.4
+              otp: 21.3.8.24
           - pair:
-              elixir: 1.13.3
-              otp: 24.2.2
+              elixir: 1.13.4
+              otp: 24.3.4.2
             lint: lint
     steps:
       - uses: actions/checkout@v2

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,0 @@
-use Mix.Config


### PR DESCRIPTION
The 18.04 runner is being deprecated. It might be why https://github.com/elixir-ecto/connection/pull/18 has failed CI jobs with this message: 

>This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.